### PR TITLE
Development action

### DIFF
--- a/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/jenkins-trigger.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - development
-      - development-action
   pull_request:
     branches:
       - development
-      - development-action
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/jenkins-trigger.yml
@@ -1,0 +1,46 @@
+name: Trigger Jenkins Jobs
+
+on:
+  push:
+    branches:
+      - development
+      - development-action
+  pull_request:
+    branches:
+      - development
+      - development-action
+  workflow_dispatch:
+
+jobs:
+  trigger-jobs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Definir variables
+        run: |
+          echo "JENKINS_BASE=https://automation.prms.cgiar.org" >> $GITHUB_ENV
+          echo "BRANCH_NAME=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+          echo "JOBS=prms-planning-dev-server-docker prms-planning-dev-client-docker" >> $GITHUB_ENV
+
+      - name: Disparar jobs en Jenkins
+        env:
+          JENKINS_BASE: ${{ env.JENKINS_BASE }}
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}
+          JOBS: ${{ env.JOBS }}
+        run: |
+          set -euo pipefail
+          for JOB in $JOBS; do
+            URL="${JENKINS_BASE}/job/${JOB}/build"
+            echo "→ running: $URL"
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+              --user "${JENKINS_USERNAME}:${JENKINS_API_TOKEN}" \
+              "$URL")
+
+            if [ "$HTTP_STATUS" -ge 400 ]; then
+              echo "✗ Failed $JOB (HTTP $HTTP_STATUS)"
+              exit 1
+            else
+              echo "✓ OK $JOB (HTTP $HTTP_STATUS)"
+            fi
+          done


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate triggering Jenkins jobs whenever there are pushes or pull requests to the `development` branch, or when manually dispatched. This helps streamline the CI/CD process by integrating GitHub and Jenkins.

**Automation and CI/CD Integration:**

* Added `.github/workflows/jenkins-trigger.yml` to define a workflow that triggers Jenkins jobs on push, pull request, or manual dispatch events for the `development` branch.
* Configured the workflow to run on `ubuntu-latest` and set up environment variables for Jenkins base URL, branch name, and a list of Jenkins jobs to trigger.
* Implemented a step to trigger specified Jenkins jobs using `curl`, handling authentication with secrets and reporting success or failure based on HTTP status codes.